### PR TITLE
Remove unused log4j logger variables and imports.

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/azure/azure/AzureManager.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/azure/AzureManager.groovy
@@ -7,13 +7,10 @@ import com.microsoft.azure.management.compute.VirtualMachineSize
 import com.microsoft.azure.management.resources.fluentcore.arm.Region
 import com.microsoft.azure.management.resources.fluentcore.utils.SdkContext
 import com.rundeck.plugins.azure.util.AzurePluginUtil
-import org.apache.log4j.Logger
 /**
  * Created by luistoledo on 11/6/17.
  */
 class AzureManager {
-
-    static Logger LOG = Logger.getLogger(AzureManager.class);
 
     String clientId
     String tenantId

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureResourceModelSource.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureResourceModelSource.groovy
@@ -10,14 +10,12 @@ import com.rundeck.plugins.azure.azure.AzureManager
 import com.rundeck.plugins.azure.azure.AzureManagerBuilder
 import com.rundeck.plugins.azure.azure.AzureNode
 import com.rundeck.plugins.azure.azure.AzureNodeMapper
-import org.apache.log4j.Logger
 
 /**
  * Created by luistoledo on 11/6/17.
  */
 class AzureResourceModelSource  implements ResourceModelSource {
 
-    static Logger logger = Logger.getLogger(AzureResourceModelSource.class);
     private Properties configuration;
     private AzureManager manager;
 


### PR DESCRIPTION
The log4j logger and import cause the plugin in a 3.3.0 to blow up and they aren't used. This PR removes them.