### PR TITLE
Add Default "AzureVM" tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 out
 .gradle
 /.idea
+.DS_Store

--- a/src/main/groovy/com/rundeck/plugins/azure/azure/AzureNodeMapper.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/azure/AzureNodeMapper.groovy
@@ -141,6 +141,8 @@ class AzureNodeMapper {
             }
         }
 
+        tagSet.add("AzureVM")
+
         return tagSet
     }
 


### PR DESCRIPTION
Adding a default tag of `AzureVM` to all nodes created using this plugin to allow Azure Health Check to filter for these nodes specifically.