### PR TITLE
RUN-826: Fixes CVE-2021-31684

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
         pluginLibs("com.squareup.retrofit2:adapter-rxjava:2.6.1")  {
             because "retrofit version by azure affected by CVE-2018-1000844"
         }
+        pluginLibs("net.minidev:json-smart:2.4.8")  {
+            because "version 2.4.2 affected by CVE-2021-31684"
+        }
     }
 
 }


### PR DESCRIPTION
This fixes a high severity vuln.
More information can be found [here](https://nvd.nist.gov/vuln/detail/CVE-2021-31684).