### PR TITLE
RUN-1024: Azure Log Storage generates duplicated folder for executions

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -67,6 +67,12 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
     )
     private String path
 
+    @PluginProperty(
+        title = "Container Name",
+        description = "Define the container name where the logs will be saved. Default: rundeck",
+        defaultValue = "The base of the path set. Eg: If the path=\"project/\${job.project}/\${job.execid}\" then the containerName property will be \"project\""
+    )
+    public String containerName = null
 
     Map<String, ?> context;
     CloudBlobClient serviceClient
@@ -120,13 +126,10 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
         serviceClient = account.createCloudBlobClient();
 
         // Container name must be lower case.
-        String containerName = expandedPath.substring(0,expandedPath.indexOf("/")).toLowerCase()
+        this.containerName = this.containerName ? this.containerName.toLowerCase : expandedPath.substring(0,expandedPath.indexOf("/")).toLowerCase()
+        
         container = serviceClient.getContainerReference(containerName)
         container.createIfNotExists()
-
-
-
-
     }
 
     @Override

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -69,7 +69,7 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
 
     @PluginProperty(
         title = "Container Name",
-        description = "Define the container name where the logs will be saved. Default: rundeck",
+        description = "Define the container name where the logs will be saved.",
         defaultValue = "The base of the path set. Eg: If the path=\"project/\${job.project}/\${job.execid}\" then the containerName property will be \"project\""
     )
     public String containerName = null

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -69,8 +69,7 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
 
     @PluginProperty(
         title = "Container Name",
-        description = "Define the container name where the logs will be saved.",
-        defaultValue = "The base of the path set. Eg: If the path=\"project/\${job.project}/\${job.execid}\" then the containerName property will be \"project\""
+        description = "(Optional) Define the container name where the logs will be saved. If not set, it'll be obtained from `path` property. Eg: If the path=\"project/\${job.project}/\${job.execid}\" then the containerName property will be \"project\""
     )
     public String containerName = null
 

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -71,7 +71,7 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
         title = "Container Name",
         description = "(Optional) Define the container name where the logs will be saved. If not set, it'll be obtained from `path` property. Eg: If the path=\"project/\${job.project}/\${job.execid}\" then the containerName property will be \"project\""
     )
-    public String containerName = null
+    protected String containerName = null
 
     Map<String, ?> context;
     CloudBlobClient serviceClient


### PR DESCRIPTION
This is necessary for [this fix](https://github.com/rundeckpro/rundeckpro/pull/2626) to work. This is the minimum change necessary to fix the issue without affecting backwards compatibility.

Fix: https://github.com/rundeckpro/rundeckpro/issues/2604