### PR TITLE
RSE-109: Enh: Allow Azure resource model to filter by many resourceGroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Settings related to the Azure connection
 Mapping and filter settings
 
 * **Mapping Params**: Custom mapping settings. Property mapping definitions. Specify multiple mappings in the form "attributeName.selector=selector" or "attributeName.default=value", separated by ";"
-* **Resource Group**:  Filter using resource group
+* **Resource Groups**:  Filter using a list of allowed resource groups separated by semicolons (`;`). Eg: `RG1; RG2; RG3`
 * **Only Running Instances**: Filter for the "Running" instances. If false, all instances will be returned.
 
 ### Mapping

--- a/src/main/groovy/com/rundeck/plugins/azure/azure/AzureManagerBuilder.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/azure/AzureManagerBuilder.groovy
@@ -14,7 +14,7 @@ class AzureManagerBuilder {
     String pfxCertificatePath
     String pfxCertificatePassword
 
-    String resourceGroup
+    List<String> resourceGroups
     String tagName
     String tagValue
     boolean onlyRunningInstances
@@ -86,8 +86,8 @@ class AzureManagerBuilder {
      * @param resourceGroup Azure Resource Group
      * @return this builder
      */
-    AzureManagerBuilder resourceGroup(String resourceGroup){
-        this.resourceGroup = resourceGroup
+    AzureManagerBuilder resourceGroups(List resourceGroups){
+        this.resourceGroups = resourceGroups
         return this
     }
 
@@ -155,7 +155,7 @@ class AzureManagerBuilder {
         azure.setKey(this.key)
         azure.setPfxCertificatePath(this.pfxCertificatePath)
         azure.setPfxCertificatePassword(this.pfxCertificatePassword)
-        azure.setResourceGroup(this.resourceGroup)
+        azure.setResourceGroups(this.resourceGroups)
         azure.setOnlyRunningInstances(this.onlyRunningInstances)
         azure.setDebug(debug)
         azure.setTagName(this.tagName)

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureResourceModelSource.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureResourceModelSource.groovy
@@ -42,13 +42,19 @@ class AzureResourceModelSource  implements ResourceModelSource {
         String key=configuration.getProperty(AzureResourceModelSourceFactory.KEY)
         String pfxCertificatePath=configuration.getProperty(AzureResourceModelSourceFactory.PFX_CERTIFICATE_PATH)
         String pfxCertificatePassword=configuration.getProperty(AzureResourceModelSourceFactory.PFX_CERTIFICATE_PASSWORD)
-        String resourceGroup=configuration.getProperty(AzureResourceModelSourceFactory.RESOURCE_GROUP)
         boolean onlyRunningInstances=Boolean.parseBoolean(configuration.getProperty(AzureResourceModelSourceFactory.RUNNING_ONLY))
         String tagName=configuration.getProperty(AzureResourceModelSourceFactory.TAG_NAME)
         String tagValue=configuration.getProperty(AzureResourceModelSourceFactory.TAG_VALUE)
         String extraMapping=configuration.getProperty(AzureResourceModelSourceFactory.EXTRA_MAPPING)
         boolean useAzureTags=Boolean.parseBoolean(configuration.getProperty(AzureResourceModelSourceFactory.USE_AZURE_TAGS))
         String keyStoragePath=configuration.getProperty(AzureResourceModelSourceFactory.KEY_STORAGE_PATH)
+
+        List<String> resourceGroups = []
+        String [] rawResourceGroupStrs = configuration.getProperty(AzureResourceModelSourceFactory.RESOURCE_GROUPS)?.split(AzureResourceModelSourceFactory.RESOURCE_GROUP_SEPARATOR)
+        if(rawResourceGroupStrs)
+            for( int i = 0 ; i < rawResourceGroupStrs.size() ; i++)
+                resourceGroups << rawResourceGroupStrs[i].trim()
+
 
         if(keyStoragePath){
             KeyStorageTree keyStorage = services.getService(KeyStorageTree.class)
@@ -69,7 +75,7 @@ class AzureResourceModelSource  implements ResourceModelSource {
                     .key(key)
                     .pfxCertificatePath(pfxCertificatePath)
                     .pfxCertificatePassword(pfxCertificatePassword)
-                    .resourceGroup(resourceGroup)
+                    .resourceGroups(resourceGroups)
                     .onlyRunningInstances(onlyRunningInstances)
                     .tagName(tagName)
                     .tagValue(tagValue)

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureVmStartPlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureVmStartPlugin.groovy
@@ -96,7 +96,7 @@ class AzureVmStartPlugin  implements StepPlugin, Describable {
                 .key(key)
                 .pfxCertificatePath(pfxCertificatePath)
                 .pfxCertificatePassword(pfxCertificatePassword)
-                .resourceGroup(resourceGroup)
+                .resourceGroups([resourceGroup])
                 .build()
 
         Map<String, String> meta = new HashMap<>();

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureVmStopPlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureVmStopPlugin.groovy
@@ -100,7 +100,7 @@ class AzureVmStopPlugin  implements StepPlugin, Describable {
                 .key(key)
                 .pfxCertificatePath(pfxCertificatePath)
                 .pfxCertificatePassword(pfxCertificatePassword)
-                .resourceGroup(resourceGroup)
+                .resourceGroups([resourceGroup])
                 .build()
 
         Map<String, String> meta = new HashMap<>();


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-109

#### Problem
This plugin was able to select all VMs or the VMs on ONE resource group only.

#### Solution
Now it is possible get VMs from more than one resource group using the semicolon (;). Besides that a space at each side of the ; is accepted for better user's readability
Valid Resource group examples

```
RG1;RG2;RG3
RG1; RG2; RG3
RG1 ; RG2 ; RG3
RG1 ;RG2 ;RG3
```

The plugin will take that list and fetch the VMs from each resource group before joining them in the list of node that will be returned to rundeck