### PR TITLE
 RSE-812: Fix: not importing logs from azure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ configurations {
 
 dependencies {
     implementation 'org.codehaus.groovy:groovy-all:3.0.9'
-    implementation group: 'org.rundeck', name: 'rundeck-core', version: '4.3.+'
+    implementation group: 'org.rundeck', name: 'rundeck-core', version: '4.17.2-rc1-20231025'
 
     pluginLibs (group: 'com.microsoft.azure', name: 'azure', version: '1.41.4'){
         exclude group: "com.fasterxml.jackson.core"

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -131,6 +131,10 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
         container.createIfNotExists()
     }
 
+    protected static boolean isImportedExecution(Map<String, ?> context){
+        return context != null && context.get("isRemoteFilePath") != null && context.get("isRemoteFilePath") == "true"
+    }
+
     @Override
     boolean isAvailable(String filetype) throws ExecutionFileStorageException {
         try {
@@ -225,7 +229,10 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
      */
     static String expandPath(String pathFormat, Map<String, ?> context) {
         String result = pathFormat.replaceAll("^/+", "");
-        if (null != context) {
+
+        if(isImportedExecution(context))
+            result = String.valueOf(context.get("outputfilepath").toString())
+        else if (null != context) {
             result = DataContextUtils.replaceDataReferences(
                     result,
                     DataContextUtils.addContext("job", stringMap(context), new HashMap<>()),
@@ -252,12 +259,16 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
     }
 
     String getFileName(String fileType){
-        String executionId=context.get(META_EXECID)
-        String project=context.get(META_PROJECT)
+        String fileName
+        if(isImportedExecution(this.context))
+            fileName = expandedPath.substring(expandedPath.indexOf("/"), expandedPath.length()).toLowerCase()
+        else{
+            String executionId=context.get(META_EXECID)
+            String project=context.get(META_PROJECT)
+            fileName = "${project}/${executionId}"
+        }
 
-        String fileName="${project}/${executionId}.${fileType}"
-
-        return fileName
+        return fileName + ".${fileType}"
     }
 
 

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -310,5 +310,8 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
         return blob
     }
 
-
+    @Override
+    public String getConfiguredPathTemplate(){
+        return this.path;
+    }
 }

--- a/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePlugin.groovy
@@ -131,6 +131,10 @@ class AzureFileStoragePlugin implements ExecutionFileStoragePlugin, ExecutionMul
         container.createIfNotExists()
     }
 
+    /**
+     * @param context execution context
+     * @return true if the given context has the expanded path of the log files in the `outputfilepath` variable
+     */
     protected static boolean isImportedExecution(Map<String, ?> context){
         return context != null && context.get("isRemoteFilePath") != null && context.get("isRemoteFilePath") == "true"
     }

--- a/src/test/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePluginSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/azure/plugin/AzureFileStoragePluginSpec.groovy
@@ -53,6 +53,21 @@ class AzureFileStoragePluginSpec  extends Specification{
         thrown IllegalArgumentException
     }
 
+    def "return true if it was initialized with an imported execution"(){
+        when:
+        boolean isImportedExecution = AzureFileStoragePlugin.isImportedExecution(context)
+
+        then:
+        isImportedExecution == expected
+
+        where:
+        context                      | expected
+        ['isRemoteFilePath': 'asd']  | false
+        ['isRemoteFilePath': 'true'] | true
+        [:]                          | false
+        null                         | false
+    }
+
 
     private HashMap<String, Object> testContext() {
         HashMap<String, Object> stringHashMap = new HashMap<String, Object>();


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-740
Depends on: https://github.com/rundeck/rundeck/pull/8583

Support the use of outputfilepath execution context variable to access log files in case the isRemoteFilePath variable is true, meaning is an imported execution.