### PR TITLE
RUN-2901: Removes commons-io from packaged dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload azure plugin jar
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy-all:3.0.9'
     implementation group: 'org.rundeck', name: 'rundeck-core', version: '4.17.2-rc1-20231025'
 
+    implementation group: 'commons-io', name: 'commons-io', version: '2.18.0'
+    pluginLibs group: 'commons-net', name: 'commons-net', version: '3.11.1'
+
     pluginLibs (group: 'com.microsoft.azure', name: 'azure', version: '1.41.4'){
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "net.minidev", module: "json-smart"
@@ -53,8 +56,6 @@ dependencies {
         exclude group: "net.minidev", module: "json-smart"
         exclude group: 'com.google.guava', module: 'guava'
     }
-    pluginLibs group: 'commons-net', name: 'commons-net', version: '3.9.0'
-    pluginLibs group: 'commons-io', name: 'commons-io', version: '2.12.0'
 
     // https://mvnrepository.com/artifact/com.microsoft.azure/azure-keyvault-core
     pluginLibs (group: 'com.microsoft.azure', name: 'azure-keyvault-core', version: '1.0.0') {
@@ -89,7 +90,7 @@ jar {
         def libList = configurations.pluginLibs.collect{'lib/' + it.name}.join(' ')
         attributes 'Rundeck-Plugin-Name' : pluginName
         attributes 'Rundeck-Plugin-Description' : pluginDescription
-        attributes 'Rundeck-Plugin-Rundeck-Compatibility-Version': '2.8.2+'
+        attributes 'Rundeck-Plugin-Rundeck-Compatibility-Version': '4.17.0+'
         attributes 'Rundeck-Plugin-Tags': 'java,executor file storage,resource model,workflow step,azure'
         attributes 'Rundeck-Plugin-License': 'Apache 2.0'
         attributes 'Rundeck-Plugin-Source-Link': 'https://github.com/rundeck-plugins/rundeck-azure-plugin'


### PR DESCRIPTION
Removes commons-io from packaged dependencies to address CVE-2024-47554

commons-io is included wiithin rundeck hence there's no need to include it in the plugin.