### PR TITLE
RUN-3086: Pin the okhttp version to 4.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,11 @@ dependencies {
         pluginLibs ('com.nimbusds:nimbus-jose-jwt:9.37.3') {
             because "CVE-2023-1370, CVE-2021-31684, CVE-2023-52428"
         }
+        // Pins the version to avoid  a dependency on okhttp 3.14.9 that suffers from the CVE.
+        // This version of okhttp is inline with the one used in Rundeck 5.9.x
+        pluginLibs ('com.squareup.okhttp3:okhttp:4.12.0') {
+            because "CVE-2023-3635"
+        }
     }
 
 }


### PR DESCRIPTION
Jira ticket: [RUN-3086](https://pagerduty.atlassian.net/browse/RUN-3086?atlOrigin=eyJpIjoiMmM1NWYyYTNkMzRkNDI5MWJjYTNlMTNmODZjNGM4YTQiLCJwIjoiaiJ9)

- Pin the okhttp version to 4.12.0

