### PR TITLE
Create jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Jitpack built the latest release but rundeckpro timeout and fails to download the pom. There's a warning on jitpack logs:

```
⚠️  WARNING:  - Incompatible because this component declares an API of a component compatible with Java 11 and the consumer needed a runtime of a component compatible with Java 8
Please specify Java version in jitpack.yml
See documentation at https://docs.jitpack.io/building/#java-version
```

