### PR TITLE
RUN-3674: Mitigate CVE-2023-1370

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
         pluginLibs(libs.nimbusJoseJwt) {
             because "CVE-2023-1370, CVE-2021-31684, CVE-2023-52428"
         }
+        pluginLibs(libs.jsonSmart) {
+            because "CVE-2023-1370 - upgrade from 2.4.2 to 2.5.0"
+        }
         // Pins the version to avoid a dependency on okhttp 3.14.9 that suffers from the CVE.
         // This version of okhttp is inline with the one used in Rundeck 5.9.x
         pluginLibs(libs.okhttp) {


### PR DESCRIPTION
What was the issue?
The CVE-2023-1370 vulnerability was present because:

The Azure SDK (com.microsoft.azure:azure@1.41.4) was transitively pulling in net.minidev:json-smart@2.4.2
This older version (2.4.2) contained the security vulnerability
The fix required upgrading to version 2.4.9 or later
How it was fixed:
By adding the constraint:

This forces Gradle to use version 2.5.0 (as defined in your libs.versions.toml) instead of the vulnerable 2.4.2 version that was being pulled in transitively.