### PR TITLE
RUN-3674: More JSON Smart Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,12 @@ repositories {
 
 // Force resolution of json-smart to mitigate CVE-2023-1370
 configurations.all {
-    resolutionStrategy.force 'net.minidev:json-smart:2.5.0'
+    resolutionStrategy {
+        force 'net.minidev:json-smart:2.5.0'
+        dependencySubstitution {
+            substitute module('net.minidev:json-smart:2.4.2') using module('net.minidev:json-smart:2.5.0') because 'CVE-2023-1370'
+        }
+    }
 }
 
 
@@ -61,6 +66,7 @@ dependencies {
     pluginLibs(libs.azure) {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
     pluginLibs libs.jsonSmart
     pluginLibs(libs.azureStorage) {

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,17 @@ repositories {
 // Force resolution of json-smart to mitigate CVE-2023-1370
 configurations.all {
     resolutionStrategy {
-        force 'net.minidev:json-smart:2.5.0'
+        force 'net.minidev:json-smart:2.5.2'
         dependencySubstitution {
-            substitute module('net.minidev:json-smart:2.4.2') using module('net.minidev:json-smart:2.5.0') because 'CVE-2023-1370'
+            substitute module('net.minidev:json-smart:2.4.2') using module('net.minidev:json-smart:2.5.2') because 'CVE-2023-1370'
+        }
+        // Explicitly reject vulnerable versions
+        componentSelection {
+            withModule('net.minidev:json-smart') { ComponentSelection selection ->
+                if (selection.candidate.version == '2.4.2') {
+                    selection.reject('Vulnerable to CVE-2023-1370')
+                }
+            }
         }
     }
 }
@@ -86,8 +94,11 @@ dependencies {
         implementation(libs.nimbusJoseJwt) {
             because "CVE-2023-1370, CVE-2021-31684, CVE-2023-52428"
         }
+        implementation(libs.oauth2OidcSdk) {
+            because "CVE-2023-1370 - upgrade to version that doesn't depend on vulnerable json-smart"
+        }
         implementation(libs.jsonSmart) {
-            because "CVE-2023-1370 - upgrade from 2.4.2 to 2.5.0"
+            because "CVE-2023-1370 - upgrade from 2.4.2 to 2.5.2"
         }
         implementation(libs.okhttp) {
             because "CVE-2023-3635"
@@ -98,8 +109,11 @@ dependencies {
         pluginLibs(libs.nimbusJoseJwt) {
             because "CVE-2023-1370, CVE-2021-31684, CVE-2023-52428"
         }
+        pluginLibs(libs.oauth2OidcSdk) {
+            because "CVE-2023-1370 - upgrade to version that doesn't depend on vulnerable json-smart"
+        }
         pluginLibs(libs.jsonSmart) {
-            because "CVE-2023-1370 - upgrade from 2.4.2 to 2.5.0"
+            because "CVE-2023-1370 - upgrade from 2.4.2 to 2.5.2"
         }
         // Pins the version to avoid a dependency on okhttp 3.14.9 that suffers from the CVE.
         // This version of okhttp is inline with the one used in Rundeck 5.9.x

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 axionRelease = "1.18.18"
 groovy = "3.0.24"
-rundeckCore = "5.14.0-rc1-20250722"
+rundeckCore = "5.15.0-rc1-20250821"
 nexusPublish = "2.0.0"
 azureSdk = "1.41.4"
 azureStorage = "8.6.6"
@@ -11,7 +11,8 @@ commonsNet = "3.11.1"
 okhttp = "4.12.0"
 retrofit = "2.9.0"
 nimbusJoseJwt = "9.37.3"
-jsonSmart = "2.5.0"
+oauth2OidcSdk = "11.20.1"
+jsonSmart = "2.5.2"
 junit = "4.13.2"
 spock = "2.0-groovy-3.0"
 cglib = "2.2.2"
@@ -33,6 +34,7 @@ commonsNet = { group = "commons-net", name = "commons-net", version.ref = "commo
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 retrofitAdapterRxjava = { group = "com.squareup.retrofit2", name = "adapter-rxjava", version.ref = "retrofit" }
 nimbusJoseJwt = { group = "com.nimbusds", name = "nimbus-jose-jwt", version.ref = "nimbusJoseJwt" }
+oauth2OidcSdk = { group = "com.nimbusds", name = "oauth2-oidc-sdk", version.ref = "oauth2OidcSdk" }
 jsonSmart = { group = "net.minidev", name = "json-smart", version.ref = "jsonSmart" }
 
 # Testing


### PR DESCRIPTION
**For Eng Reviewer** Please help with build/release and update in the product.


SUCCESS! A local Snyk scan confirms that CVE-2023-1370 has been successfully resolved. Here's what we accomplished:

**Test Results**
CVE-2023-1370 eliminated: The original vulnerability in json-smart@2.4.2 is no longer present
Related DoS vulnerability fixed: We also resolved a newer DoS vulnerability by upgrading to json-smart@2.5.2
No more json-smart findings: Snyk shows zero vulnerabilities related to json-smart at any severity level

**Final Configuration**
json-smart version: Upgraded from 2.4.2 → 2.5.2
oauth2-oidc-sdk version: Upgraded from 9.4 → 11.20.1 (which eliminates the vulnerable dependency path entirely)
Multiple protection layers: Force resolution, dependency substitution, and component selection rules