### PR TITLE
RUN-4569 Mitigate Jackson CVE-2026-54512/54513

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-axionRelease = "1.18.18"
+axionRelease = "1.21.2"
 groovy = "4.0.29"
-rundeckCore = "6.0.0-alpha1-20260407"
+rundeckCore = "6.1.0-SNAPSHOT"
 nexusPublish = "2.0.0"
 azureSdk = "1.41.4"
 azureStorage = "8.6.6"


### PR DESCRIPTION
## Summary
- Bump `rundeck-core` to `6.1.0-SNAPSHOT`, which pulls patched `jackson-databind` 2.22.0 transitively, mitigating CVE-2026-54512 / CVE-2026-54513.
- Standardize the axion-release plugin to 1.21.2.

## Test plan
- [x] `rundeck-core:6.1.0-SNAPSHOT` and `jackson-databind:2.22.0` resolve on compileClasspath (verified locally).
- [ ] CI build and Snyk scan pass on the branch.